### PR TITLE
Add shift-tab targeting

### DIFF
--- a/terongame/index.html
+++ b/terongame/index.html
@@ -22,6 +22,8 @@
 	<script src="src/prefabs/WinOverlay.js"></script>
 	<script src="src/prefabs/LoseOverlay.js"></script>
 	
+	<script src="src/ShifTabDispatcher.js"></script>
+
 	<script src="src/scenes/Preload.js"></script>
 	<script src="src/scenes/Intro.js"></script>
 	<script src="src/scenes/TeronGame.js"></script>

--- a/terongame/src/ShifTabDispatcher.js
+++ b/terongame/src/ShifTabDispatcher.js
@@ -2,7 +2,7 @@ let shiftTabDispatcherInstance = null;
 class ShifTabDispatcher extends Phaser.Events.EventEmitter {
 	constructor() {
 		super();
-        this._isJustDown = false       
+		this._isJustDown = false       
 	}
 
 	static ShiftTabEvent = 'shifttab'
@@ -15,15 +15,15 @@ class ShifTabDispatcher extends Phaser.Events.EventEmitter {
 	}
 
 	shifTabDown() {
-        if (!this._isJustDown) {
-            console.log('Emitting shiftab Event')
-            ShifTabDispatcher.getInstance().emit(ShifTabDispatcher.ShiftTabEvent)
-            this._isJustDown = true
-        }
+		if (!this._isJustDown) {
+			console.log('Emitting shiftab Event')
+			ShifTabDispatcher.getInstance().emit(ShifTabDispatcher.ShiftTabEvent)
+			this._isJustDown = true
+		}
 	}
 
 	shifTabUp() {
-        this._isJustDown = false;
+		this._isJustDown = false;
 	}
 }
 

--- a/terongame/src/ShifTabDispatcher.js
+++ b/terongame/src/ShifTabDispatcher.js
@@ -1,0 +1,29 @@
+let shiftTabDispatcherInstance = null;
+class ShifTabDispatcher extends Phaser.Events.EventEmitter {
+	constructor() {
+		super();
+        this._isJustDown = false       
+	}
+
+    static ShiftTabEvent = 'shifttab'
+
+	static getInstance() {
+		if (shiftTabDispatcherInstance == null) {
+			shiftTabDispatcherInstance = new ShifTabDispatcher();
+		}
+		return shiftTabDispatcherInstance;
+	}
+
+    shifTabDown() {
+        if (!this._isJustDown) {
+            console.log('Emitting shiftab Event')
+            ShifTabDispatcher.getInstance().emit(ShifTabDispatcher.ShiftTabEvent)
+            this._isJustDown = true
+        }
+    }
+
+    shifTabUp() {
+        this._isJustDown = false;
+    }
+}
+

--- a/terongame/src/ShifTabDispatcher.js
+++ b/terongame/src/ShifTabDispatcher.js
@@ -16,7 +16,6 @@ class ShifTabDispatcher extends Phaser.Events.EventEmitter {
 
 	shifTabDown() {
 		if (!this._isJustDown) {
-			console.log('Emitting shiftab Event')
 			ShifTabDispatcher.getInstance().emit(ShifTabDispatcher.ShiftTabEvent)
 			this._isJustDown = true
 		}

--- a/terongame/src/ShifTabDispatcher.js
+++ b/terongame/src/ShifTabDispatcher.js
@@ -5,7 +5,7 @@ class ShifTabDispatcher extends Phaser.Events.EventEmitter {
         this._isJustDown = false       
 	}
 
-    static ShiftTabEvent = 'shifttab'
+	static ShiftTabEvent = 'shifttab'
 
 	static getInstance() {
 		if (shiftTabDispatcherInstance == null) {
@@ -14,16 +14,16 @@ class ShifTabDispatcher extends Phaser.Events.EventEmitter {
 		return shiftTabDispatcherInstance;
 	}
 
-    shifTabDown() {
+	shifTabDown() {
         if (!this._isJustDown) {
             console.log('Emitting shiftab Event')
             ShifTabDispatcher.getInstance().emit(ShifTabDispatcher.ShiftTabEvent)
             this._isJustDown = true
         }
-    }
+	}
 
-    shifTabUp() {
+	shifTabUp() {
         this._isJustDown = false;
-    }
+	}
 }
 

--- a/terongame/src/main.js
+++ b/terongame/src/main.js
@@ -6,7 +6,7 @@ window.addEventListener('load', function () {
 		width: 600,
 		height: 800,
 		type: Phaser.AUTO,
-        backgroundColor: "#242424",
+		backgroundColor: "#242424",
 		scale: {
 			mode: Phaser.Scale.FIT,
 			autoCenter: Phaser.Scale.CENTER_BOTH

--- a/terongame/src/main.js
+++ b/terongame/src/main.js
@@ -25,6 +25,19 @@ window.addEventListener('load', function () {
 	game.scene.add("Boot", Boot, true);
 });
 
+window.addEventListener('keydown', function(e) {
+	if (e.key === 'Tab' && e.shiftKey) {
+		ShifTabDispatcher.getInstance().shifTabDown();
+		e.preventDefault()
+	}
+})
+
+window.addEventListener('keyup', function(e) {
+	if (e.key === 'Tab') {
+		ShifTabDispatcher.getInstance().shifTabUp();
+	}
+})
+
 class Boot extends Phaser.Scene {
 
 	preload() {

--- a/terongame/src/scenes/TeronGame.js
+++ b/terongame/src/scenes/TeronGame.js
@@ -9,7 +9,7 @@ class TeronGame extends Phaser.Scene {
 		super("TeronGame");
 
 		/* START-USER-CTR-CODE */
-		this.shifTabDispatcher = ShifTabDispatcher.getInstance();
+		// Write your code here.
 		/* END-USER-CTR-CODE */
 	}
 
@@ -696,7 +696,7 @@ class TeronGame extends Phaser.Scene {
 		});
 
 		let me = this;
-		this.shifTabDispatcher.on(ShifTabDispatcher.ShiftTabEvent, function() {
+		ShifTabDispatcher.getInstance().on(ShifTabDispatcher.ShiftTabEvent, function() {
 			me.shifttab = true;
 		});
 	}

--- a/terongame/src/scenes/TeronGame.js
+++ b/terongame/src/scenes/TeronGame.js
@@ -3,35 +3,13 @@
 
 /* START OF COMPILED CODE */
 
-window.addEventListener('keydown', function(e) {
-	if (e.key === 'Tab' && e.shiftKey) {
-		let emitter = EventDispatcher.getInstance();
-		emitter.emit('shifttab');
-		e.preventDefault();
-	}
-})
-
-let instance = null;
-class EventDispatcher extends Phaser.Events.EventEmitter {
-	constructor() {
-		super();       
-	}
-
-	static getInstance() {
-		if (instance == null) {
-			instance = new EventDispatcher();
-		}
-		return instance;
-	}
-}
-
 class TeronGame extends Phaser.Scene {
 
 	constructor() {
 		super("TeronGame");
 
 		/* START-USER-CTR-CODE */
-		this.emitter = EventDispatcher.getInstance();
+		this.shifTabDispatcher = ShifTabDispatcher.getInstance();
 		/* END-USER-CTR-CODE */
 	}
 
@@ -718,7 +696,7 @@ class TeronGame extends Phaser.Scene {
 		});
 
 		let me = this;
-		this.emitter.on('shifttab', function() {
+		this.shifTabDispatcher.on(ShifTabDispatcher.ShiftTabEvent, function() {
 			me.shifttab = true;
 		});
 	}

--- a/terongame/src/scenes/TeronGame.js
+++ b/terongame/src/scenes/TeronGame.js
@@ -13,16 +13,16 @@ window.addEventListener('keydown', function(e) {
 
 let instance = null;
 class EventDispatcher extends Phaser.Events.EventEmitter {
-    constructor() {
-        super();       
-    }
+	constructor() {
+		super();       
+	}
 
 	static getInstance() {
-        if (instance == null) {
-            instance = new EventDispatcher();
-        }
-        return instance;
-    }
+		if (instance == null) {
+			instance = new EventDispatcher();
+		}
+		return instance;
+	}
 }
 
 class TeronGame extends Phaser.Scene {


### PR DESCRIPTION
This is a hack to enable shift-tab-targeting which selects the previous target. Since the default behavior of shift-tab is to move the focus out of the game window I use a catch-all listener on the window to prevent that, and then use a global event dispatcher singleton to transfer the window event into the scene. Not that pretty but it works :)